### PR TITLE
Fix negative array indexing

### DIFF
--- a/core/src/test/resources/io.idml.ast/IndexSuite.json
+++ b/core/src/test/resources/io.idml.ast/IndexSuite.json
@@ -48,19 +48,23 @@
     "input": {"a": [10]},
     "output": {"b": 10}
   },
-
   {
     "name": "last item - missing",
     "mapping": "b = a[-1]",
     "input": {"a": []},
     "output": {}
   },
-
+   {
+    "name": "last item - longer list",
+    "mapping": "b = a[-1]",
+    "input": {"a": [1,2,3]},
+    "output": {"b":  3}
+  },
   {
-    "name": "allow wrapping on all negative indexes",
+    "name": "not allow wrapping on all negative indexes",
     "mapping": "b = a[-10]",
     "input": {"a": [10, 11, 12, 13]},
-    "output": {"b": 12}
+    "output": {}
   },
 
   {

--- a/datanodes/src/main/scala/io/idml/PtolemyArray.scala
+++ b/datanodes/src/main/scala/io/idml/PtolemyArray.scala
@@ -24,7 +24,7 @@ trait PtolemyArray extends PtolemyValue with CompositeValue {
   /** Wrap an index so we can support negatives but overflows should always return nothing */
   protected def wrapIndex(index: Int, size: Int): Int = {
     if (index < 0) {
-      math.abs(index % size.max(1))
+      size + index
     } else {
       index
     }


### PR DESCRIPTION
Previously we only tested for 1 item lists, this has been expanded.

I've also removed the repeated wrapping for very negative indexes, because that just didn't make any sense, we now only wrap once.