### PR TITLE
Fix incorrect case in geo function table names

### DIFF
--- a/geo/src/main/scala/io/idml/geo/Admin1Function.scala
+++ b/geo/src/main/scala/io/idml/geo/Admin1Function.scala
@@ -29,7 +29,7 @@ class Admin1Function(driver: String, url: String, user: String, password: String
   }
 
   def find(id: Long): ConnectionIO[Option[Admin1]] =
-    sql"select * from admin1 where id = $id".query[Admin1].option
+    sql"select * from Admin1 where id = $id".query[Admin1].option
 
   def get(id: Long): Option[PtolemyValue] =
     find(id)

--- a/geo/src/main/scala/io/idml/geo/CityFunction.scala
+++ b/geo/src/main/scala/io/idml/geo/CityFunction.scala
@@ -29,7 +29,7 @@ class CityFunction(driver: String, url: String, user: String, password: String) 
   }
 
   def find(id: Long): ConnectionIO[Option[City]] =
-    sql"select * from cities where id = $id".query[City].option
+    sql"select * from Cities where id = $id".query[City].option
 
   def get(id: Long): Option[PtolemyValue] =
     find(id)


### PR DESCRIPTION
The data dumps that are used to generate these tables create tables with
leading upper-case characters:

  * `Admin1`
  * `Cities`
  * `Translations`

sqlite doesn't seem to care about this, but other database engines do.