### PR TITLE
Add `timezone` method to the geo module

### DIFF
--- a/geo/build.sbt
+++ b/geo/build.sbt
@@ -4,6 +4,7 @@ libraryDependencies ++= Seq(
   "org.xerial"        % "sqlite-jdbc"    % "3.21.0.1",
   "org.tpolecat"      %% "doobie-core"   % "0.6.0-M2",
   "org.tpolecat"      %% "doobie-hikari" % "0.6.0-M2",
+  "net.iakovlev"      % "timeshape"      % "2018d.6",
   "org.scalatest"     %% "scalatest"     % "3.0.4" % Test,
   "com.storm-enroute" %% "scalameter"    % "0.8.2" % Test
 )

--- a/geo/src/main/scala/io/idml/geo/GeoFunctionResolver.scala
+++ b/geo/src/main/scala/io/idml/geo/GeoFunctionResolver.scala
@@ -14,6 +14,8 @@ class GeoFunctionResolver extends FunctionResolver {
         Some(IsoCountryFunction(country))
       case ("region", (country: Pipeline) :: (region: Pipeline) :: Nil) =>
         Some(IsoRegionFunction(country, region))
+      case ("timezone", Nil) =>
+        Some(TimezoneFunction.TimezoneFunction)
       case _ => None
     }
   }
@@ -24,6 +26,7 @@ class GeoFunctionResolver extends FunctionResolver {
     PtolemyFunctionMetadata("region", List("region"   -> "region name to look up"), "look up a region"),
     PtolemyFunctionMetadata("city", List("city"       -> "city name to look up"), "look up a city"),
     PtolemyFunctionMetadata("admin1", List("admin1"   -> "admin1 name to look up"), "look up an admin1 area"),
+    PtolemyFunctionMetadata("timezone", List.empty, "turn this geo into a timezone, eg. Europe/London")
   )
 }
 

--- a/geo/src/main/scala/io/idml/geo/TimezoneFunction.scala
+++ b/geo/src/main/scala/io/idml/geo/TimezoneFunction.scala
@@ -1,0 +1,31 @@
+package io.idml.geo
+
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.hikari._
+import doobie.implicits._
+import io.idml._
+import io.idml.ast.Pipeline
+import io.idml.datanodes.{PInt, PObject, PString}
+import io.idml.functions.PtolemyFunction1
+import net.iakovlev.timeshape.TimeZoneEngine
+
+class TimezoneFunction {
+  val engine: TimeZoneEngine = TimeZoneEngine.initialize()
+
+  def query(g: Geo): Option[String] = {
+    engine.query(g.lat, g.long).map[Option[String]](r => Some(r.toString)).orElse(None)
+  }
+
+  case class TimezoneFunction(arg: Pipeline) extends PtolemyFunction1 {
+    override protected def apply(cursor: PtolemyValue, country: PtolemyValue): PtolemyValue = {
+      country match {
+        case g: Geo =>  query(g).map(PString).getOrElse(MissingField)
+        case _       => InvalidParameters
+      }
+    }
+
+    override def name: String = "timezone"
+  }
+}

--- a/geo/src/main/scala/io/idml/geo/TimezoneFunction.scala
+++ b/geo/src/main/scala/io/idml/geo/TimezoneFunction.scala
@@ -8,21 +8,21 @@ import doobie.implicits._
 import io.idml._
 import io.idml.ast.Pipeline
 import io.idml.datanodes.{PInt, PObject, PString}
-import io.idml.functions.PtolemyFunction1
+import io.idml.functions.PtolemyFunction0
 import net.iakovlev.timeshape.TimeZoneEngine
 
-class TimezoneFunction {
-  val engine: TimeZoneEngine = TimeZoneEngine.initialize()
+object TimezoneFunction {
+  lazy val engine: TimeZoneEngine = TimeZoneEngine.initialize()
 
   def query(g: Geo): Option[String] = {
     engine.query(g.lat, g.long).map[Option[String]](r => Some(r.toString)).orElse(None)
   }
 
-  case class TimezoneFunction(arg: Pipeline) extends PtolemyFunction1 {
-    override protected def apply(cursor: PtolemyValue, country: PtolemyValue): PtolemyValue = {
-      country match {
-        case g: Geo =>  query(g).map(PString).getOrElse(MissingField)
-        case _       => InvalidParameters
+  case object TimezoneFunction extends PtolemyFunction0 {
+    override protected def apply(cursor: PtolemyValue): PtolemyValue = {
+      cursor match {
+        case g: Geo => query(g).map(PString).getOrElse(MissingField)
+        case _      => InvalidParameters
       }
     }
 

--- a/geo/src/test/scala/io/idml/geo/TimezoneSpec.scala
+++ b/geo/src/test/scala/io/idml/geo/TimezoneSpec.scala
@@ -4,14 +4,12 @@ import org.scalatest.{MustMatchers, WordSpec}
 
 class TimezoneSpec extends WordSpec with MustMatchers {
 
-  val tz = new TimezoneFunction()
-
   "the timezone function" should {
     "know the timezone of Reading" in {
-      tz.query(Geo(51.459, -0.9722)) must equal(Some("Europe/London"))
+      TimezoneFunction.query(Geo(51.459, -0.9722)) must equal(Some("Europe/London"))
     }
     "know the timezone of Christchurch, NZ" in {
-      tz.query(Geo(-43.53, 172.62)) must equal(Some("Pacific/Auckland"))
+      TimezoneFunction.query(Geo(-43.53, 172.62)) must equal(Some("Pacific/Auckland"))
     }
   }
 

--- a/geo/src/test/scala/io/idml/geo/TimezoneSpec.scala
+++ b/geo/src/test/scala/io/idml/geo/TimezoneSpec.scala
@@ -1,0 +1,18 @@
+package io.idml.geo
+import io.idml.datanodes.PString
+import org.scalatest.{MustMatchers, WordSpec}
+
+class TimezoneSpec extends WordSpec with MustMatchers {
+
+  val tz = new TimezoneFunction()
+
+  "the timezone function" should {
+    "know the timezone of Reading" in {
+      tz.query(Geo(51.459, -0.9722)) must equal(Some("Europe/London"))
+    }
+    "know the timezone of Christchurch, NZ" in {
+      tz.query(Geo(-43.53, 172.62)) must equal(Some("Pacific/Auckland"))
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a new 0-argument function called `timezone` which can be run on any `Geo` object, and returns a string with the timezone of the coordinates.

Example:
```
idml> result = {"latitude": 51.459, "longitude": -0.9722}.geo().timezone()
....> 
{
  "result" : "Europe/London"
}
```