### PR TITLE
Swap to using jsoup's clean mode with whitespace preserved

### DIFF
--- a/jsoup/src/main/scala/io/idml/jsoup/StripTagsFunction.scala
+++ b/jsoup/src/main/scala/io/idml/jsoup/StripTagsFunction.scala
@@ -4,15 +4,18 @@ import io.idml.datanodes.PString
 import io.idml.{InvalidCaller, PtolemyContext}
 import io.idml.ast.{Pipeline, PtolemyFunction}
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.safety.Whitelist
 
 object StripTagsFunction extends PtolemyFunction {
+  final val settings = new Document.OutputSettings().prettyPrint(false)
 
   override def name: String = "stripTags"
 
   override def invoke(ctx: PtolemyContext): Unit = {
     ctx.cursor = ctx.cursor match {
       case PString(str) =>
-        PString(Jsoup.parse(str).text())
+        PString(Jsoup.clean(str, "", Whitelist.none(), settings))
       case _ =>
         InvalidCaller
     }

--- a/jsoup/src/test/resources/tests/StripTagsSuite.json
+++ b/jsoup/src/test/resources/tests/StripTagsSuite.json
@@ -16,13 +16,13 @@
   },
 
   {
-    "name": "stripTags wants to treat <efg as an implicit <efg>",
+    "name": "stripTags won't strip whitespace",
     "mapping": "a = b.stripTags()",
     "input": {
-      "b": "ab>cd<efg"
+      "b": "abcd.\n123 <br> "
     },
     "output": {
-      "a": "ab>cd"
+      "a": "abcd.\n123  "
     }
   },
 


### PR DESCRIPTION
Previously the `stripTags` function would strip all \ns and multi-space occurances to clean the text, leading to slightly unexpected results.

By using it's clean mode with explicit settings for pretty printing disabled it no longer mangles the whitespace.