### PR TITLE
Add `languageName` function to core

### DIFF
--- a/core/src/main/scala/io/idml/functions/BuiltinFunctionResolver.scala
+++ b/core/src/main/scala/io/idml/functions/BuiltinFunctionResolver.scala
@@ -43,6 +43,10 @@ class BuiltinFunctionResolver extends FunctionResolver {
         Some(GroupsByFunction(expression))
       case ("filter", (pred: Predicate) :: Nil) =>
         Some(FilterFunction(pred))
+      case ("languageName", Nil) =>
+        Some(LanguageNameFunctions.LanguageNameFunction0)
+      case ("languageName", (targetLocale: Pipeline) :: Nil) =>
+        Some(LanguageNameFunctions.LanguageNameFunction1(targetLocale))
       case _ =>
         None
     }
@@ -77,6 +81,8 @@ class BuiltinFunctionResolver extends FunctionResolver {
     ),
     IdmlFunctionMetadata("filter",
                          List("predicate" -> "filtering predicate"),
-                         "returns a new list with only the items which match the predicate")
+                         "returns a new list with only the items which match the predicate"),
+    IdmlFunctionMetadata("languageName", List.empty, "look up the name of this ISO language code"),
+    IdmlFunctionMetadata("languageName", List("targetLocale" -> "language code to look up the name in"), "look up the name of this ISO language code")
   )
 }

--- a/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
+++ b/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
@@ -12,7 +12,7 @@ object LanguageNameFunctions {
     targetLocale.fold(lang.getDisplayLanguage)(t => lang.getDisplayLanguage(Locale.forLanguageTag(t))) match {
       // Java can just return the original input if it didn't know, and we'll blank that out
       // if you do want the java behaviour, use (code.languageName() | code)
-      case result if result == code => MissingField // Java can just return us the input, which we'll blank out as an unsuccessful call, if you want this behaviour do
+      case result if result == code => MissingField
       case result => IString(result)
     }
   }

--- a/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
+++ b/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
@@ -1,0 +1,39 @@
+package io.idml.functions
+import io.idml.ast.Pipeline
+import io.idml.datanodes.IString
+import io.idml.{IdmlString, IdmlValue, InvalidCaller, InvalidParameters, MissingField}
+
+import java.util.Locale
+
+object LanguageNameFunctions {
+
+  private def lookupLanguageWithLocale(code: String, targetLocale: Option[String]): IdmlValue = {
+    val lang = Locale.forLanguageTag(code)
+    targetLocale.fold(lang.getDisplayLanguage)(t => lang.getDisplayLanguage(Locale.forLanguageTag(t))) match {
+      // Java can just return the original input if it didn't know, and we'll blank that out
+      // if you do want the java behaviour, use (code.languageName() | code)
+      case result if result == code => MissingField // Java can just return us the input, which we'll blank out as an unsuccessful call, if you want this behaviour do
+      case result => IString(result)
+    }
+  }
+
+  object LanguageNameFunction0 extends IdmlFunction0 {
+    override protected def apply(cursor: IdmlValue): IdmlValue = cursor match {
+      case s: IdmlString =>  lookupLanguageWithLocale(s.value, None)
+      case _ => InvalidCaller
+    }
+
+    override def name: String = "languageName"
+  }
+
+  case class LanguageNameFunction1(arg: Pipeline) extends IdmlFunction1 {
+    override protected def apply(cursor: IdmlValue, targetLocale: IdmlValue): IdmlValue = (cursor, targetLocale) match {
+      case (s: IdmlString, t: IdmlString) => lookupLanguageWithLocale(s.value, Some(t.value))
+      case (_: IdmlString, _) => InvalidParameters
+      case _ => InvalidCaller
+    }
+
+    override def name: String = "languageName"
+  }
+
+}

--- a/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
+++ b/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
@@ -24,6 +24,12 @@
     "output": {"output": "Dansk"}
   },
   {
+    "name": "languageName with a manual locale of chinese",
+    "mapping": "output = input.languageName(\"zh\")",
+    "input": {"input": "da"},
+    "output": {"output": "丹麦文"}
+  },
+  {
     "name": "languageName with null input",
     "mapping": "output = input.languageName()",
     "input": {},

--- a/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
+++ b/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
@@ -6,6 +6,12 @@
     "output": {"output": "English"}
   },
   {
+    "name": "languageName default locale with a 3-char input",
+    "mapping": "output = input.languageName()",
+    "input": {"input": "ban"},
+    "output": {"output": "Balinese"}
+  },
+  {
     "name": "languageName with manual locale of en",
     "mapping": "output = input.languageName(\"en\")",
     "input": {"input": "da"},

--- a/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
+++ b/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "languageName default locale",
+    "mapping": "output = input.languageName()",
+    "input": {"input": "en"},
+    "output": {"output": "English"}
+  },
+  {
+    "name": "languageName with manual locale of en",
+    "mapping": "output = input.languageName(\"en\")",
+    "input": {"input": "da"},
+    "output": {"output": "Danish"}
+  },
+  {
+    "name": "languageName with a manual locale of danish",
+    "mapping": "output = input.languageName(\"da\")",
+    "input": {"input": "da"},
+    "output": {"output": "Dansk"}
+  },
+  {
+    "name": "languageName with null input",
+    "mapping": "output = input.languageName()",
+    "input": {},
+    "output": {}
+  },
+  {
+    "name": "languageName with int input",
+    "mapping": "output = input.languageName()",
+    "input": {"input":  123},
+    "output": {}
+  },
+  {
+    "name": "languageName with invalid input",
+    "mapping": "output = input.languageName()",
+    "input": {"input":  "blargh"},
+    "output": {}
+  },
+  {
+    "name": "languageName with null input and a manual locale",
+    "mapping": "output = input.languageName(\"en\")",
+    "input": {},
+    "output": {}
+  }
+]


### PR DESCRIPTION
Adds two new functions:
* `input.languageName()` will look the input up as an ISO language code, and find the name of the language in the JVM's default locale
* `input.languageName("en")` will look the input up as an ISO language code, and find the name of the language in the described target locale

Both functions are in `core` since they just rely on JVM internals, and are available in `BuiltinFunctionResolver`
Tests have been added in `LanguageNameSuite.json`

Note that `java.util.Locale` can just return the input if it doesn't recognise it, so we intercept that and turn it into a `MissingField`.
If you'd like that behaviour please use `(input.languageName() | input)` to fall back to the input.