### PR TITLE
Call getDisplayName when returning language name

### DIFF
--- a/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
+++ b/core/src/main/scala/io/idml/functions/LanguageNameFunctions.scala
@@ -9,7 +9,7 @@ object LanguageNameFunctions {
 
   private def lookupLanguageWithLocale(code: String, targetLocale: Option[String]): IdmlValue = {
     val lang = Locale.forLanguageTag(code)
-    targetLocale.fold(lang.getDisplayLanguage)(t => lang.getDisplayLanguage(Locale.forLanguageTag(t))) match {
+    targetLocale.fold(lang.getDisplayName)(t => lang.getDisplayName(Locale.forLanguageTag(t))) match {
       // Java can just return the original input if it didn't know, and we'll blank that out
       // if you do want the java behaviour, use (code.languageName() | code)
       case result if result == code => MissingField

--- a/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
+++ b/test/src/test/resources/io.idml.functions/LanguageNameSuite.json
@@ -12,6 +12,18 @@
     "output": {"output": "Balinese"}
   },
   {
+    "name": "languageName default locale with code of zh-Hans",
+    "mapping": "output = input.languageName()",
+    "input": {"input": "zh-Hans"},
+    "output": {"output": "Chinese (Simplified)"}
+  },
+  {
+    "name": "languageName default locale with code of zh-Hant",
+    "mapping": "output = input.languageName()",
+    "input": {"input": "zh-Hant"},
+    "output": {"output": "Chinese (Traditional)"}
+  },
+  {
     "name": "languageName with manual locale of en",
     "mapping": "output = input.languageName(\"en\")",
     "input": {"input": "da"},
@@ -28,6 +40,12 @@
     "mapping": "output = input.languageName(\"zh\")",
     "input": {"input": "da"},
     "output": {"output": "丹麦文"}
+  },
+  {
+    "name": "languageName with manual locale of en and code of zh-hans",
+    "mapping": "output = input.languageName(\"en\")",
+    "input": {"input": "zh-Hans"},
+    "output": {"output": "Chinese (Simplified)"}
   },
   {
     "name": "languageName with null input",


### PR DESCRIPTION
As per https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#getDisplayName(java.util.Locale), calling `getDisplayName()` will return values from `getDisplayLanguage()`, `getDisplayScript()`, `getDisplayCountry()`, and `getDisplayVariant()` assemble into a single string. The non-empty values are used in order, with the second and subsequent names in parentheses.

Consequently, it will provide more information than calling `getDisplayLanguage()` by itself.