### PR TITLE
Fix loss of precision when converting float to int

### DIFF
--- a/datanodes/src/main/scala/io/idml/datanodes/IDouble.scala
+++ b/datanodes/src/main/scala/io/idml/datanodes/IDouble.scala
@@ -9,7 +9,7 @@ case class IDouble(value: Double) extends IdmlDouble {
   override def float(): IDouble = this
 
   /** Transform this value into a natural number */
-  override def int(): IdmlValue = IdmlValue(value.toInt)
+  override def int(): IdmlValue = IdmlValue(value.toLong)
 
   override def toDoubleOption = Some(value)
 }


### PR DESCRIPTION
When calling `.int()` on a floating-point number, we were incorrectly
marshalling to a 32-bit integer (aka. `Int`), instead of a 64-bit integer (aka.
`Long`), which could result in the result being bounded at `2147483647`
(the maximum signed 32-bit integer) unnecessarily.

Since all "integers" in IDML are 64-bit, there's no reason to marshall a
floating point number to a 32-bit number.

Example:
```
json> { "foo": 1739180023809489.0 }
~> bar = foo.int()
..
{
  "bar" : 2147483647
}
```

Changing to `toLong` yields this result:
```
json> { "foo": 1739180023809489.0 }
~> bar = foo.int()
..
{
  "bar" : 1739180023809489
}
```

This should not cause any regressions, as it is unlikely that any users
are depending on this "bounding" behaviour.
