### PR TITLE
Upgrade to Antlr4 4.10.1 and build with Java 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ scalastyle-output.xml
 idml.jar
 .bloop
 .metals
+.bsp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from hseeberger/scala-sbt:8u212_1.2.8_2.13.0 as sbt
+from sbtscala/scala-sbt:amazoncorretto-al2023-17.0.16_1.12.11_2.13.18 as sbt
 copy . /build/
 workdir /build/
 run sbt "project tool" "docker:stage"

--- a/build.sbt
+++ b/build.sbt
@@ -74,13 +74,7 @@ lazy val commonSettings = Seq(
   }
 )
 
-lazy val lang = project
-  .settings(commonSettings)
-  .settings(
-    Antlr4 / antlr4Version     := "4.8-1",
-    Antlr4 / antlr4PackageName := Some("io.idml.lang"),
-    Antlr4 / antlr4GenVisitor  := true
-  )
+lazy val lang = project.settings(commonSettings)
 
 lazy val datanodes = project.settings(commonSettings)
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,6 +4,6 @@ libraryDependencies ++= Seq(
   "org.slf4j"          % "slf4j-api"   % "1.7.26",
   "org.tpolecat"      %% "atto-core"   % "0.9.4",
   "org.scalatest"     %% "scalatest"   % "3.2.8"   % Test,
-  "org.mockito"        % "mockito-all" % "1.9.5"   % Test,
-  "org.scalatestplus" %% "mockito-3-4" % "3.2.8.0" % Test
+  "org.mockito"        % "mockito-core"  % "4.11.0"   % Test,
+  "org.scalatestplus" %% "mockito-4-11" % "3.2.18.0" % Test
 )

--- a/idmltutor/build.sbt
+++ b/idmltutor/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= List(
 )
 
 libraryDependencies ++= Seq(
-  "org.mockito"    % "mockito-all" % "1.9.5" % Test,
+  "org.mockito"    % "mockito-core" % "4.11.0" % Test,
   "org.scalatest" %% "scalatest"   % "3.2.8" % Test
 )
 

--- a/lang/build.sbt
+++ b/lang/build.sbt
@@ -6,10 +6,12 @@ antlr4GenListener in Antlr4 := true
 
 antlr4GenVisitor in Antlr4 := true
 
-antlr4Version in Antlr4 := "4.5"
+antlr4PackageName in Antlr4 := Some("io.idml.lang")
+
+antlr4Version in Antlr4 := "4.10.1"
 
 antlr4Dependency in Antlr4 :=
-  "org.antlr"               % "antlr4" % "4.5" exclude ("org.antlr", "ST4") exclude ("org.antlr", "antlr-runtime") // BSD license
+  "org.antlr" % "antlr4" % "4.10.1"
 
 libraryDependencies ++= Seq(
   "com.google.guava" % "guava"     % "27.0-jre", // Apache License 2

--- a/lang/src/main/antlr4/Mapping.g4
+++ b/lang/src/main/antlr4/Mapping.g4
@@ -1,7 +1,6 @@
 grammar Mapping;
 
-document : section* |
-           mapping*;
+document : (section* | mapping*) EOF;
 
 section : header mapping*;
 

--- a/repl/build.sbt
+++ b/repl/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"   %% "fansi"               % "0.2.13",
   "org.jline"      % "jline-terminal-jna"  % "3.13.3",
   "org.jline"      % "jline-reader"        % "3.13.3",
-  "org.mockito"    % "mockito-all"         % "1.9.5" % Test,
+  "org.mockito"    % "mockito-core"        % "4.11.0" % Test,
   "org.scalatest" %% "scalatest"           % "3.2.8" % Test
 )
 

--- a/test/build.sbt
+++ b/test/build.sbt
@@ -4,8 +4,8 @@ publishArtifact := false
 
 libraryDependencies ++= List(
   "org.scalatest"     %% "scalatest"     % "3.2.8"   % Test,
-  "org.mockito"        % "mockito-all"   % "1.9.0"   % Test,
-  "org.scalatestplus" %% "mockito-3-4"   % "3.2.8.0" % Test,
+  "org.mockito"        % "mockito-core"  % "4.11.0"   % Test,
+  "org.scalatestplus" %% "mockito-4-11" % "3.2.18.0" % Test,
   "com.storm-enroute" %% "scalameter"    % "0.19"    % Test,
   "io.circe"          %% "circe-testing" % "0.13.0"  % Test,
   "org.scalatest"     %% "scalatest"     % "3.2.8"   % Test


### PR DESCRIPTION
Moves the project's runtime/build baseline to Java 17, target is still 1.8. 
Bumps the ANTLR4 tool/runtime from effectively-4.5 setup to 4.10.1. Along the way, fixed two things the version bumps broke: a Mockito/JDK17 incompatibility and a real grammar bug the old ANTLR version happened to mask.

- Antlr4: 4.5 → 4.10.1
- Mokcito 1 -> 4
- Grammar fix:

The version bump surfaced a real bug, caught by the existing IdmlParserTest ("Throws parse error when input is invalid"). The document rule was:
  
```  
document : section* | mapping*;
```
  
Both alternatives can match zero tokens, which is an inherent ambiguity. Under ANTLR 4.5 this happened to still throw on garbage input. Under 4.10.1's improved ATN resolution, the same ambiguous rule instead resolves immediately to an empty match without any lookahead check — so invalid input like `:-D` silently parsed to an empty Document instead of raising DocumentParseException.
Fix: require the entire input to be consumed —

`document : (section* | mapping*) EOF;`
    
This is the standard ANTLR4 idiom for an entry rule and doesn't affect AstGenerator.visitDocument, which only reads ctx.section()/ctx.mapping().

